### PR TITLE
Adding timestamps for video 02-tim-mikkel-grigorios.md

### DIFF
--- a/videos-list/02-tim-mikkel-grigorios.md
+++ b/videos-list/02-tim-mikkel-grigorios.md
@@ -13,9 +13,19 @@ Discourse Discussion
 https://discourse.pymc.io/t/the-mlda-multilevel-sampler-in-pymc3-by-tim-dodwell-mikkel-lykkegaard-and-grigorios-mingas/5982
 
 ## Timestamps
-- 0:00 Start of event
-- x:xx 
-- x:xx
+- 0:00 Introduction
+- 0:36 A three way plan of attack!
+- 3:21 Bayesian Uncertainty Quantification - Vanilla MCMC Starts with Bayes' Theorem
+- 6:13 Delayed Acceptance - Christen & Fox, 2005
+- 7:39 Multilevel Delayed Acceptance - Adpt 1 - Finite Subchains
+- 8:33 Multilevel Delayed Acceptance - Adpt 2 - Apply Recursively
+- 9:50 MLDA in PyMC3
+- 22:21 Correcting Coarse Models
+- 23:40 Coarse Model Bias
+- 25:01 Modelling the Bias
+- 26:41 Adaptive Error Model
+- 27:53 Example
+- 38:43 What we would like from you - Contacts
 
 ## Note: help us add timestamps here
 https://github.com/pymc-devs/video-timestamps


### PR DESCRIPTION
### Reference
Towards #11 
Closes #53 

### Description
Adding timestamps to video [02-tim-mikkel-grigorios.md](https://github.com/pymc-devs/video-timestamps/blob/main/videos-list/02-tim-mikkel-grigorios.md) - [Tim D, Mikkel L and Grigorios M, MLDA multilevel sampler by Tim Dodwell, Mikkel Lykkegaard, and Grigorios Mingas](https://www.youtube.com/watch?v=NvsGyvAElLY)

### Event
#PyMCon 2020